### PR TITLE
Allow searching via Console

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ module.exports = class ModuleFinder extends Plugin {
     powercord.api.commands.registerCommand({ command: "findmodules", executor: this.handleCommand.bind(null, this.findModules.bind(null, 0)) });
     powercord.api.commands.registerCommand({ command: "findconstants", executor: this.handleCommand.bind(null, this.findModules.bind(null, 1)) });
     powercord.api.commands.registerCommand({ command: "findcomponents", executor: this.handleCommand.bind(null, this.findComponents) });
+
+    window.findModule = this.findModules.bind(null, 0);
+    window.findConstant = this.findModules.bind(null, 1);
+    window.findComponent = this.findComponents.bind(null);
   }
 
   handleCommand(fn, args) {
@@ -57,5 +61,9 @@ module.exports = class ModuleFinder extends Plugin {
     powercord.api.commands.unregisterCommand("findmodules");
     powercord.api.commands.unregisterCommand("findconstants");
     powercord.api.commands.unregisterCommand("findcomponents");
+
+    delete window.findModule;
+    delete window.findConstant;
+    delete window.findComponent;
   }
 };

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,6 @@
   "author": "Vendicated",
   "name": "ModuleFinder",
   "description": "Easily find modules, components or constants by keyboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Should for some reason the commands cause a crash, this will allow continued usage of the Plugin by using the respective global functions.

In electron context
`findModule`
`findComponent`
`findConstant`
![image](https://user-images.githubusercontent.com/52699291/185803450-010597c8-f71e-4495-9697-95b6f40762cf.png)
